### PR TITLE
Move requirements declaration into setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-setuptools==18.5
-beautifulsoup4==4.6.3
-mkdocs==1.0.4

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ setup(
     license='MIT',
     python_requires='>=2.7',
     install_requires=[
-        'mkdocs>=0.17'
+        'setuptools>=18.5',
+        'beautifulsoup4>=4.6.3',
+        'mkdocs>=1.0.4',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This ensures that the requirements are properly satisfied automatically when anyone installs this package, rather than requiring them to look in the source.