### PR TITLE
Code blocks with a langauge specification have classes with the format language-*

### DIFF
--- a/markdownmermaid/plugin.py
+++ b/markdownmermaid/plugin.py
@@ -9,21 +9,19 @@ except NameError:
 
 
 class MarkdownMermaidPlugin(BasePlugin):
-   
     def on_post_page(self, output_content, config, **kwargs):
         soup = BeautifulSoup(output_content, 'html.parser')
-        mermaids = soup.find_all("code",class_="mermaid")
-        hasMermaid = 0
+        mermaids = soup.find_all("code", class_="language-mermaid")
         for mermaid in mermaids:
-            hasMermaid = 1
             # replace code with div
-            mermaid.name="div"
-            # replace <pre> 
+            mermaid.name = "div"
+            mermaid['class'] = "mermaid"
+            # replace <pre>
             mermaid.parent.replace_with(mermaid)
 
-        if(hasMermaid==1):
+        if mermaids:
             new_tag = soup.new_tag("script")
-            new_tag.string="mermaid.initialize();"
+            new_tag.string = "mermaid.initialize();"
             soup.body.append(new_tag)
-            
+
         return unicode(soup)


### PR DESCRIPTION
In the latest mkdocs versions, the code blocks classes are formatted is seen in the title of this pull request. This pull request add support for these new classes. 

I also refactored the code to make it follow the Python style guides.